### PR TITLE
CI: Fix bitrot and deprecation warnings. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Packages
         run: |
-          make dist
+          make build
 
       - name: Upload Packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
 
     env:
       RELEASE_FILE: ${{ github.event.repository.name }}-${{ github.event.release.tag_name || github.sha }}-py${{ matrix.python }}
+      TERM: xterm-256color
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -35,7 +35,7 @@ jobs:
           make dist
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RELEASE_FILE }}
           path: dist/

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: linting & spelling
     runs-on: ubuntu-latest
+    env:
+      TERM: xterm-256color
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python '3,11'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff --format=github .
+	ruff check --output-format=github .
 	codespell .
 deps =
 	check-manifest


### PR DESCRIPTION
Fix the pesky bitrot I ran into while working on https://github.com/pinout-xyz/rpipins/pull/5